### PR TITLE
Display missing overlay sections

### DIFF
--- a/src/ndsware/extract_nds.py
+++ b/src/ndsware/extract_nds.py
@@ -170,13 +170,18 @@ def info(nds_file: str) -> None:
         print(f"{name:40} {value}")
 
 
-def log_section(name: str, section_info: Nds.FatEntry | Nds.SectionInfo | Nds.CodeSectionInfo) -> tuple[int, int, str]:
+def log_section(
+    name: str, section_info: Nds.FatEntry | Nds.OverlayEntry | Nds.SectionInfo | Nds.CodeSectionInfo
+) -> tuple[int, int, str]:
     """
     Converts section information into a common format: `(start_offset, end_offset, name)`
     """
 
     if isinstance(section_info, Nds.FatEntry):
         return section_info.start_offset, section_info.end_offset, name
+
+    if isinstance(section_info, Nds.OverlayEntry):
+        return section_info.start_address, section_info.end_address, name
 
     return section_info.offset, section_info.offset + section_info.size, name
 
@@ -204,6 +209,12 @@ def sections(nds_file: str) -> None:
 
     for i, entry in enumerate(nds.file_allocation_table):
         data_sections.append(log_section(f"FILE {i}", entry))
+
+    for i, entry in enumerate(nds.arm9_overlay_table.entries):
+        data_sections.append(log_section(f"ARM9 Overlay {i}", entry))
+
+    for i, entry in enumerate(nds.arm7_overlay_table.entries):
+        data_sections.append(log_section(f"ARM7 Overlay {i}", entry))
 
     data_sections.sort()
 


### PR DESCRIPTION
The `sections` command now displays the address range of each overlay section in the NDS ROM.

Also, the output section names of the overlay tables have been changed from "ARM9 Overlay" and "ARM7 Overlay" to "ARM9 Overlay Table" and "ARM7 Overlay Table". This makes it clear that these sections contain overlay entries and not the actual overlay data.