### PR TITLE
Add graphics extractor tool

### DIFF
--- a/definitions/g2d.ksy
+++ b/definitions/g2d.ksy
@@ -85,11 +85,14 @@ types:
       - id: graphics_data_offset
         type: u4
       - id: graphics_data
-        type: graphics_data
+        type: graphics_data(4 << colour_format)
         size: graphics_data_size
-        
+          
   graphics_data:
+    params:
+      - id: tile_size
+        type: u4
     seq:
       - id: tiles
-        size: 32
+        size: tile_size
         repeat: eos

--- a/definitions/g2d.ksy
+++ b/definitions/g2d.ksy
@@ -1,0 +1,95 @@
+meta:
+  id: g2d
+  endian: le
+  encoding: utf-8
+
+seq:
+  - id: header
+    type: header
+  - id: blocks
+    type: block
+    repeat: expr
+    repeat-expr: header.block_count
+    
+types:
+  header:
+    -webide-representation: '{magic}'
+    seq:
+      - id: magic
+        type: str
+        size: 4
+      - id: byte_order
+        type: u2
+      - id: version
+        type: u2
+      - id: file_size
+        type: u4
+      - id: header_size
+        type: u2
+      - id: block_count
+        type: u2
+
+  block:
+    -webide-representation: '{magic}'
+    seq:
+      - id: magic
+        type: str
+        size: 4
+      - id: size
+        type: u4
+      - id: data
+        type:
+          switch-on: magic
+          cases:
+            '"TTLP"': pltt_block
+            '"RAHC"': char_block
+            
+  #####################
+  #### NCLR Blocks ####
+  #####################
+        
+  pltt_block:
+    seq:
+      - id: colour_format
+        type: u4
+      - id: extended_palette
+        type: u4
+      - id: palette_data_size
+        type: u4
+      - id: palette_data_offset
+        type: u4
+    
+    instances:
+      palette_data:
+        pos: _io.pos - 16 + palette_data_offset
+        size: palette_data_size
+        
+  #####################
+  #### NCGR Blocks ####
+  #####################
+  
+  char_block:
+    seq:
+      - id: width
+        type: u2
+      - id: height
+        type: u2
+      - id: colour_format
+        type: u4
+      - id: mapping_mode
+        type: u4
+      - id: graphics_type
+        type: u4
+      - id: graphics_data_size
+        type: u4
+      - id: graphics_data_offset
+        type: u4
+      - id: graphics_data
+        type: graphics_data
+        size: graphics_data_size
+        
+  graphics_data:
+    seq:
+      - id: tiles
+        size: 32
+        repeat: eos

--- a/python-package/build/lib/ndsware/parsers/g2d.py
+++ b/python-package/build/lib/ndsware/parsers/g2d.py
@@ -1,0 +1,118 @@
+# This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+
+import kaitaistruct
+from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
+
+
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+
+class G2d(KaitaiStruct):
+    def __init__(self, _io, _parent=None, _root=None):
+        self._io = _io
+        self._parent = _parent
+        self._root = _root if _root else self
+        self._read()
+
+    def _read(self):
+        self.header = G2d.Header(self._io, self, self._root)
+        self.blocks = []
+        for i in range(self.header.block_count):
+            self.blocks.append(G2d.Block(self._io, self, self._root))
+
+
+    class PlttBlock(KaitaiStruct):
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._read()
+
+        def _read(self):
+            self.colour_format = self._io.read_u4le()
+            self.extended_palette = self._io.read_u4le()
+            self.palette_data_size = self._io.read_u4le()
+            self.palette_data_offset = self._io.read_u4le()
+
+        @property
+        def palette_data(self):
+            if hasattr(self, '_m_palette_data'):
+                return self._m_palette_data
+
+            _pos = self._io.pos()
+            self._io.seek(((self._io.pos() - 16) + self.palette_data_offset))
+            self._m_palette_data = self._io.read_bytes(self.palette_data_size)
+            self._io.seek(_pos)
+            return getattr(self, '_m_palette_data', None)
+
+
+    class CharBlock(KaitaiStruct):
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._read()
+
+        def _read(self):
+            self.width = self._io.read_u2le()
+            self.height = self._io.read_u2le()
+            self.colour_format = self._io.read_u4le()
+            self.mapping_mode = self._io.read_u4le()
+            self.graphics_type = self._io.read_u4le()
+            self.graphics_data_size = self._io.read_u4le()
+            self.graphics_data_offset = self._io.read_u4le()
+            self._raw_graphics_data = self._io.read_bytes(self.graphics_data_size)
+            _io__raw_graphics_data = KaitaiStream(BytesIO(self._raw_graphics_data))
+            self.graphics_data = G2d.GraphicsData(_io__raw_graphics_data, self, self._root)
+
+
+    class Block(KaitaiStruct):
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._read()
+
+        def _read(self):
+            self.magic = (self._io.read_bytes(4)).decode(u"utf-8")
+            self.size = self._io.read_u4le()
+            _on = self.magic
+            if _on == u"TTLP":
+                self.data = G2d.PlttBlock(self._io, self, self._root)
+            elif _on == u"RAHC":
+                self.data = G2d.CharBlock(self._io, self, self._root)
+
+
+    class Header(KaitaiStruct):
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._read()
+
+        def _read(self):
+            self.magic = (self._io.read_bytes(4)).decode(u"utf-8")
+            self.byte_order = self._io.read_u2le()
+            self.version = self._io.read_u2le()
+            self.file_size = self._io.read_u4le()
+            self.header_size = self._io.read_u2le()
+            self.block_count = self._io.read_u2le()
+
+
+    class GraphicsData(KaitaiStruct):
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._read()
+
+        def _read(self):
+            self.tiles = []
+            i = 0
+            while not self._io.is_eof():
+                self.tiles.append(self._io.read_bytes(32))
+                i += 1
+
+
+
+

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 [project.scripts]
 extract_nds = "ndsware.extract_nds:cli"
 extract_narc = "ndsware.extract_narc:cli"
+extract_graphics = "ndsware.extract_graphics:cli"
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/python-package/src/ndsware/extract_graphics.py
+++ b/python-package/src/ndsware/extract_graphics.py
@@ -2,25 +2,46 @@ import click
 from ndsware.parsers.g2d import G2d
 from PIL import Image
 
+Pixel = tuple[int, int, int, int]
+
 TILE_WIDTH = 8
 TILE_HEIGHT = 8
 GREY_SCALE = [(i * 17, i * 17, i * 17, 255) for i in range(16)]
 
 
-def decode_4bpp_tile(tile: bytes) -> list[tuple[int, int, int, int]]:
+def bgr555_to_rgb(colour: int) -> Pixel:
+    r = (colour & 0x1F) << 3
+    g = ((colour >> 5) & 0x1F) << 3
+    b = ((colour >> 10) & 0x1F) << 3
+    return (r, g, b, 255)
+
+
+def decode_palette(pltt_block: G2d.PlttBlock) -> list[Pixel]:
+    palette_data = pltt_block.palette_data
+    palette = []
+
+    for i in range(0, len(palette_data), 2):
+        colour_bytes = int.from_bytes(palette_data[i : i + 2], "little")
+        colour = bgr555_to_rgb(colour_bytes)
+        palette.append(colour)
+
+    return palette
+
+
+def decode_4bpp_tile(tile: bytes, palette: list[Pixel]) -> list[Pixel]:
     pixels = []
 
     for byte in tile:
         low_nibble = byte & 0x0F
         high_nibble = (byte >> 4) & 0x0F
-        pixels.append(GREY_SCALE[low_nibble])
-        pixels.append(GREY_SCALE[high_nibble])
+        pixels.append(palette[low_nibble])
+        pixels.append(palette[high_nibble])
 
     return pixels
 
 
-def generate_tile_image(tile: bytes) -> Image.Image:
-    pixels = decode_4bpp_tile(tile)
+def generate_tile_image(tile: bytes, palette: list[Pixel]) -> Image.Image:
+    pixels = decode_4bpp_tile(tile, palette)
 
     tile_image = Image.new("RGBA", (TILE_WIDTH, TILE_HEIGHT))
     tile_image.putdata(pixels)
@@ -28,13 +49,13 @@ def generate_tile_image(tile: bytes) -> Image.Image:
     return tile_image
 
 
-def get_char_block(ncgr: G2d) -> G2d.CharBlock:
+def get_block(g2d: G2d, block_type: str) -> G2d.CharBlock | G2d.PlttBlock:
     block: G2d.Block
-    for block in ncgr.blocks:
-        if block.magic == "RAHC":
+    for block in g2d.blocks:
+        if block.magic == block_type[::-1]:
             return block.data
 
-    raise KeyError("Missing CHAR block.")
+    raise KeyError(f"Missing {block_type} block.")
 
 
 @click.group()
@@ -56,7 +77,11 @@ def extract(ncgr_file: str, nclr_file: str, tiles_per_row: int, output_image_fil
     ncgr = G2d.from_file(ncgr_file)
     nclr = G2d.from_file(nclr_file)
 
-    tiles = get_char_block(ncgr).graphics_data.tiles
+    char_block: G2d.CharBlock = get_block(ncgr, "CHAR")
+    pltt_block: G2d.PlttBlock = get_block(nclr, "PLTT")
+
+    tiles = char_block.graphics_data.tiles
+    palette = decode_palette(pltt_block)
 
     tile_count = len(tiles)
     rows = (tile_count + tiles_per_row - 1) // tiles_per_row
@@ -64,7 +89,7 @@ def extract(ncgr_file: str, nclr_file: str, tiles_per_row: int, output_image_fil
     image = Image.new("RGBA", (tiles_per_row * TILE_WIDTH, rows * TILE_HEIGHT))
 
     for i, tile in enumerate(tiles):
-        tile_image = generate_tile_image(tile)
+        tile_image = generate_tile_image(tile, palette)
 
         # Calculate tile position in image.
         x = (i % tiles_per_row) * TILE_WIDTH

--- a/python-package/src/ndsware/extract_graphics.py
+++ b/python-package/src/ndsware/extract_graphics.py
@@ -67,22 +67,24 @@ def cli() -> None:
 
 @cli.command()
 @click.argument("ncgr_file", type=str)
-@click.argument("nclr_file", type=str)
+@click.option("-p", "--nclr-file", type=str, help="Colour palette (.nclr) file path.")
 @click.argument("tiles_per_row", type=int)
 @click.argument("output_image_file", type=click.Path(exists=False))
 def extract(ncgr_file: str, nclr_file: str, tiles_per_row: int, output_image_file: str) -> None:
     if not output_image_file.lower().endswith((".png", ".bmp")):
         raise click.BadParameter("Output file must be a valid image type (PNG or BMP).")
 
-    ncgr = G2d.from_file(ncgr_file)
-    nclr = G2d.from_file(nclr_file)
+    if nclr_file:
+        nclr = G2d.from_file(nclr_file)
+        pltt_block: G2d.PlttBlock = get_block(nclr, "PLTT")
+        palette = decode_palette(pltt_block)
+    else:
+        palette = GREY_SCALE
 
+    ncgr = G2d.from_file(ncgr_file)
     char_block: G2d.CharBlock = get_block(ncgr, "CHAR")
-    pltt_block: G2d.PlttBlock = get_block(nclr, "PLTT")
 
     tiles = char_block.graphics_data.tiles
-    palette = decode_palette(pltt_block)
-
     tile_count = len(tiles)
     rows = (tile_count + tiles_per_row - 1) // tiles_per_row
 

--- a/python-package/src/ndsware/extract_graphics.py
+++ b/python-package/src/ndsware/extract_graphics.py
@@ -1,3 +1,10 @@
+"""
+A tool for extracting images stored using the G2D binary format (i.e., NCGR and NCLR files).
+
+Author: CodeDragon82
+Data: 09/06/2025
+"""
+
 import click
 from ndsware.parsers.g2d import G2d
 from PIL import Image
@@ -96,12 +103,14 @@ def cli() -> None:
     """
 
 
-@cli.command()
+@cli.command(help="Extract the image from an NCGR file.")
 @click.argument("ncgr_file", type=str)
 @click.option("-p", "--nclr-file", type=str, help="Colour palette (.nclr) file path.")
 @click.argument("tiles_per_row", type=int)
 @click.argument("output_image_file", type=click.Path(exists=False))
 def extract(ncgr_file: str, nclr_file: str, tiles_per_row: int, output_image_file: str) -> None:
+    """Extracts an image stored in a NCGR file."""
+
     if not output_image_file.lower().endswith((".png", ".bmp")):
         raise click.BadParameter("Output file must be a valid image type (PNG or BMP).")
 

--- a/python-package/src/ndsware/extract_graphics.py
+++ b/python-package/src/ndsware/extract_graphics.py
@@ -1,0 +1,80 @@
+import click
+from ndsware.parsers.g2d import G2d
+from PIL import Image
+
+TILE_WIDTH = 8
+TILE_HEIGHT = 8
+GREY_SCALE = [(i * 17, i * 17, i * 17, 255) for i in range(16)]
+
+
+def decode_4bpp_tile(tile: bytes) -> list[tuple[int, int, int, int]]:
+    pixels = []
+
+    for byte in tile:
+        low_nibble = byte & 0x0F
+        high_nibble = (byte >> 4) & 0x0F
+        pixels.append(GREY_SCALE[low_nibble])
+        pixels.append(GREY_SCALE[high_nibble])
+
+    return pixels
+
+
+def generate_tile_image(tile: bytes) -> Image.Image:
+    pixels = decode_4bpp_tile(tile)
+
+    tile_image = Image.new("RGBA", (TILE_WIDTH, TILE_HEIGHT))
+    tile_image.putdata(pixels)
+
+    return tile_image
+
+
+def get_char_block(ncgr: G2d) -> G2d.CharBlock:
+    block: G2d.Block
+    for block in ncgr.blocks:
+        if block.magic == "RAHC":
+            return block.data
+
+    raise KeyError("Missing CHAR block.")
+
+
+@click.group()
+def cli() -> None:
+    """
+    Extracts images stored using the G2D binary format.
+    """
+
+
+@cli.command()
+@click.argument("ncgr_file", type=str)
+@click.argument("nclr_file", type=str)
+@click.argument("tiles_per_row", type=int)
+@click.argument("output_image_file", type=click.Path(exists=False))
+def extract(ncgr_file: str, nclr_file: str, tiles_per_row: int, output_image_file: str) -> None:
+    if not output_image_file.lower().endswith((".png", ".bmp")):
+        raise click.BadParameter("Output file must be a valid image type (PNG or BMP).")
+
+    ncgr = G2d.from_file(ncgr_file)
+    nclr = G2d.from_file(nclr_file)
+
+    tiles = get_char_block(ncgr).graphics_data.tiles
+
+    tile_count = len(tiles)
+    rows = (tile_count + tiles_per_row - 1) // tiles_per_row
+
+    image = Image.new("RGBA", (tiles_per_row * TILE_WIDTH, rows * TILE_HEIGHT))
+
+    for i, tile in enumerate(tiles):
+        tile_image = generate_tile_image(tile)
+
+        # Calculate tile position in image.
+        x = (i % tiles_per_row) * TILE_WIDTH
+        y = (i // tiles_per_row) * TILE_HEIGHT
+
+        # Paste tile into final image.
+        image.paste(tile_image, (x, y))
+
+    image.save(output_image_file)
+
+
+if __name__ == "__main__":
+    cli()

--- a/python-package/src/ndsware/extract_graphics.py
+++ b/python-package/src/ndsware/extract_graphics.py
@@ -10,6 +10,8 @@ GREY_SCALE = [(i * 17, i * 17, i * 17, 255) for i in range(16)]
 
 
 def bgr555_to_rgb(colour: int) -> Pixel:
+    """Converts from BGR555 2-byte format to RGB tuple format."""
+
     r = (colour & 0x1F) << 3
     g = ((colour >> 5) & 0x1F) << 3
     b = ((colour >> 10) & 0x1F) << 3
@@ -17,6 +19,8 @@ def bgr555_to_rgb(colour: int) -> Pixel:
 
 
 def decode_palette(pltt_block: G2d.PlttBlock) -> list[Pixel]:
+    """Decodes the raw palette data into a list of colour pixels."""
+
     palette_data = pltt_block.palette_data
     palette = []
 
@@ -29,6 +33,12 @@ def decode_palette(pltt_block: G2d.PlttBlock) -> list[Pixel]:
 
 
 def decode_4bpp_tile(tile: bytes, palette: list[Pixel]) -> list[Pixel]:
+    """
+    Decodes the raw tile data into a list of coloured pixels.
+
+    Each byte contains 2 pixels, one pixel per 4-bits. The 4-bits is integer
+    that represents an index in the colour palette.
+    """
     pixels = []
 
     for byte in tile:
@@ -50,6 +60,8 @@ def generate_tile_image(tile: bytes, palette: list[Pixel]) -> Image.Image:
 
 
 def get_block(g2d: G2d, block_type: str) -> G2d.CharBlock | G2d.PlttBlock:
+    """Get a block of a specific type from a parsed G2D file."""
+
     block: G2d.Block
     for block in g2d.blocks:
         if block.magic == block_type[::-1]:

--- a/python-package/src/ndsware/parsers/g2d.py
+++ b/python-package/src/ndsware/parsers/g2d.py
@@ -63,7 +63,7 @@ class G2d(KaitaiStruct):
             self.graphics_data_offset = self._io.read_u4le()
             self._raw_graphics_data = self._io.read_bytes(self.graphics_data_size)
             _io__raw_graphics_data = KaitaiStream(BytesIO(self._raw_graphics_data))
-            self.graphics_data = G2d.GraphicsData(_io__raw_graphics_data, self, self._root)
+            self.graphics_data = G2d.GraphicsData((4 << self.colour_format), _io__raw_graphics_data, self, self._root)
 
 
     class Block(KaitaiStruct):
@@ -100,17 +100,18 @@ class G2d(KaitaiStruct):
 
 
     class GraphicsData(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
+        def __init__(self, tile_size, _io, _parent=None, _root=None):
             self._io = _io
             self._parent = _parent
             self._root = _root if _root else self
+            self.tile_size = tile_size
             self._read()
 
         def _read(self):
             self.tiles = []
             i = 0
             while not self._io.is_eof():
-                self.tiles.append(self._io.read_bytes(32))
+                self.tiles.append(self._io.read_bytes(self.tile_size))
                 i += 1
 
 


### PR DESCRIPTION
Nintendo DS games typically use the G2D binary format to store 2D sprites/images. The `.ncgr` and `.nclr` files are defined by this format. The `.ncgr` files store image data, and the `.nclr` files store the colour palette data.

A Kaitai definition for the G2D binary format has been added, which can parse both NCGR and NCLR files. The new `extract_graphics` tool takes the data parsed out of an NCGR file and reconstructs the PNG or BMP image using the colour palette data from the NCLR file. If a colour palette isn't supplied, the reconstructed image will be in greyscale.

Here is some information on the G2D binary file format:
- https://wiki.dshack.org/Wiki.jsp?page=G2D%20Binary%20File%20Format
- https://wiki.dshack.org/Wiki.jsp?page=NCGR
- https://wiki.dshack.org/Wiki.jsp?page=NCLR