### PR TITLE
Add command to NDS extractor tool for traversing the NDS file system in an interactive shell

### DIFF
--- a/python-package/src/ndsware/extract_nds.py
+++ b/python-package/src/ndsware/extract_nds.py
@@ -75,6 +75,18 @@ class FileNode:
 
         return listings
 
+    def extract(self, output_path: str) -> None:
+        output_path = os.path.join(output_path, self.name)
+        print(output_path)
+
+        if self.is_directory():
+            os.makedirs(output_path, exist_ok=True)
+
+            for child in self.children:
+                child.extract(output_path)
+        else:
+            open(output_path, "wb").write(self.get_file_data())
+
     def is_directory(self) -> bool:
         return self.file is None
 

--- a/python-package/src/ndsware/extract_nds.py
+++ b/python-package/src/ndsware/extract_nds.py
@@ -17,14 +17,14 @@ from tabulate import tabulate
 CODE_FOLDER = "code"
 FILES_FOLDER = "files"
 
-file_index = 0
-
 
 class ExploreException(Exception):
     pass
 
 
 class FileNode:
+    file_index = 0
+
     def __init__(self, name: str, parent: Optional[FileNode]):
         self.name: str = name
         self.parent: Optional[FileNode] = parent
@@ -91,8 +91,6 @@ class FileNode:
         return self.file is None
 
     def load(self, nds: Nds, directory: Nds.Directory) -> None:
-        global file_index
-
         file: Nds.FileEntry
         for file in reversed(directory.files[:-1]):
             child_node = FileNode(file.name, self)
@@ -104,13 +102,12 @@ class FileNode:
 
                 child_node.load(nds, next_directory)
             else:
-                child_node.set_file(nds.files[file_index])
-                file_index -= 1
+                child_node.set_file(nds.files[FileNode.file_index])
+                FileNode.file_index -= 1
 
     @staticmethod
     def load_file_system(nds: Nds) -> FileNode:
-        global file_index
-        file_index = len(nds.files) - 1
+        FileNode.file_index = len(nds.files) - 1
 
         root_directory = nds.file_name_table.directories[0]
         root_node = FileNode("", None)

--- a/python-package/src/ndsware/extract_nds.py
+++ b/python-package/src/ndsware/extract_nds.py
@@ -2,7 +2,7 @@
 A tool for extracting file and code sections from NDS ROM.
 
 Author: CodeDragon82
-Data: 04/05/2025
+Date: 04/05/2025
 """
 
 from __future__ import annotations

--- a/python-package/src/ndsware/extract_nds.py
+++ b/python-package/src/ndsware/extract_nds.py
@@ -28,44 +28,46 @@ def cli() -> None:
 @click.argument("nds_file", type=str)
 def explore(nds_file: str) -> None:
     nds = Nds.from_file(nds_file)
-    name_path: list[str] = []
-    directory_path: list[Nds.Directory] = [nds.file_name_table.directories[0]]
+    path: dict[str, Nds.Directory] = {"": nds.file_name_table.directories[0]}
 
     while True:
-        path_string = "/" + "/".join(name_path) + " > "
+        path_string = "/".join(path.keys()) + " > "
         parts = input(path_string).split()
         command = parts[0] if parts else ""
         arguments = parts[1:] if len(parts) > 1 else []
 
-        match command:
-            case "ls":
-                for file in directory_path[-1].files[:-1]:
-                    symbol = "D" if file.is_directory else "_"
-                    print(symbol, "\t", file.name)
-            case "cd":
-                if len(arguments) > 0:
-                    change_directory(nds, name_path, directory_path, arguments[0])
-                else:
-                    print("ERROR: Must specify a directory to change to.")
-            case "exit":
-                break
+        process_explore_command(nds, path, command, arguments)
 
 
-def change_directory(nds: Nds, name_path: list, directory_path: list, next_directory: str) -> None:
+def process_explore_command(nds: Nds, path: dict[str, Nds.Directory], command: str, arguments: list[str]) -> None:
+    match command:
+        case "ls":
+            current_directory = next(reversed(path.values()))
+            for file in current_directory.files[:-1]:
+                symbol = "D" if file.is_directory else "_"
+                print(symbol, "\t", file.name)
+        case "cd":
+            if len(arguments) > 0:
+                change_directory(nds, path, arguments[0])
+            else:
+                print("ERROR: Must specify a directory to change to.")
+        case "exit":
+            raise SystemExit("Goodbye!")
+
+
+def change_directory(nds: Nds, path: dict[str, Nds.Directory], next_directory: str) -> None:
     if next_directory == "..":
-        if len(name_path) > 0:
-            name_path.pop()
-            directory_path.pop()
+        if len(path) > 1:
+            path.popitem()
         else:
             print("ERROR: Cannot traverse backwards from the root directory.")
         return
 
-    for file in directory_path[-1].files[:-1]:
+    current_directory = next(reversed(path.values()))
+    for file in current_directory.files[:-1]:
         if file.name == next_directory and file.is_directory:
             next_directory_index = file.directory_id & 0xFFF
-            next_directory = nds.file_name_table.directories[next_directory_index]
-            name_path.append(file.name)
-            directory_path.append(next_directory)
+            path[file.name] = nds.file_name_table.directories[next_directory_index]
             return
 
     print(f"ERROR: '{next_directory}' is not a directory.")

--- a/python-package/src/ndsware/extract_nds.py
+++ b/python-package/src/ndsware/extract_nds.py
@@ -64,6 +64,17 @@ class FileNode:
         size = info.end_offset - info.start_offset
         return f"_\t{self.name}\t{size} B"
 
+    def get_listings(self, recursive: bool = False, tab: int = 0) -> str:
+        listings = ""
+
+        if self.is_directory():
+            for child in self.children:
+                listings += "\t" * tab + child.get_listing() + "\n"
+                if recursive:
+                    listings += child.get_listings(recursive, tab + 1)
+
+        return listings
+
     def is_directory(self) -> bool:
         return self.file is None
 
@@ -124,8 +135,9 @@ def explore(nds_file: str) -> None:
 def process_explore_command(command: str, arguments: list[str], current_directory: FileNode) -> FileNode:
     match command:
         case "ls":
-            for file in current_directory.children:
-                print(file.get_listing())
+            print(current_directory.get_listings())
+        case "lsr":
+            print(current_directory.get_listings(recursive=True))
         case "cd":
             current_directory = change_directory(arguments, current_directory)
         case "exit":

--- a/python-package/src/ndsware/extract_nds.py
+++ b/python-package/src/ndsware/extract_nds.py
@@ -113,7 +113,7 @@ class FileNode:
         file_index = len(nds.files) - 1
 
         root_directory = nds.file_name_table.directories[0]
-        root_node = FileNode("/", None)
+        root_node = FileNode("", None)
         root_node.load(nds, root_directory)
 
         return root_node
@@ -179,51 +179,9 @@ def files(nds_file: str) -> None:
     """Displays the file/directory structure of the NDS ROM."""
 
     nds = Nds.from_file(nds_file)
+    root = FileNode.load_file_system(nds)
 
-    extract_files(nds, None)
-
-
-def extract_directory(nds: Nds, directory: Nds.Directory, indent: int, output_dir: str | None) -> None:
-    """
-    Loops through each entry in a FNT directory.
-
-    If the entry is a file, file data pointed to by the FAT is extracted and written to the new file. The
-    name of the new file defined in the entry. Then the `file_index` is then incremented.
-
-    If the entry is a directory, a new directory with the name specified in the entry is created and the
-    `extract_directory` is called again of the new directory.
-    """
-    global file_index
-
-    for file in reversed(directory.files[:-1]):
-        if output_dir is None:
-            print("\t" * indent + file.name)
-
-        if file.is_directory:
-            if output_dir:
-                output_dir = os.path.join(output_dir, file.name)
-                os.makedirs(output_dir, exist_ok=True)
-
-            next_directory_index = file.directory_id & 0xFFF
-            next_directory = nds.file_name_table.directories[next_directory_index]
-            extract_directory(nds, next_directory, indent + 1, output_dir)
-        else:
-            if output_dir:
-                file_path = os.path.join(output_dir, file.name)
-                file_data = nds.files[file_index].data
-                open(file_path, "wb").write(file_data)
-
-            file_index -= 1
-
-
-def extract_files(nds: Nds, output_dir: str | None) -> None:
-    """Fetches the root directory entry in the FNT and calls `extract_directory` on it."""
-
-    global file_index
-    file_index = len(nds.files) - 1
-
-    root = nds.file_name_table.directories[0]
-    extract_directory(nds, root, 0, output_dir)
+    print(root.get_listings(recursive=True))
 
 
 def extract_code(nds: Nds, output_dir: str) -> None:
@@ -266,6 +224,7 @@ def extract(nds_file: str, output_dir: str) -> None:
     """Extracts extracts file and code sections from the NDS ROM and writes the data to files in the `output_dir`."""
 
     nds = Nds.from_file(nds_file)
+    root = FileNode.load_file_system(nds)
 
     code_dir = os.path.join(output_dir, CODE_FOLDER)
     files_dir = os.path.join(output_dir, FILES_FOLDER)
@@ -273,7 +232,7 @@ def extract(nds_file: str, output_dir: str) -> None:
     os.makedirs(code_dir, exist_ok=True)
     os.makedirs(files_dir, exist_ok=True)
 
-    extract_files(nds, files_dir)
+    root.extract(files_dir)
     extract_code(nds, code_dir)
 
 

--- a/python-package/src/ndsware/extract_nds.py
+++ b/python-package/src/ndsware/extract_nds.py
@@ -8,9 +8,8 @@ Data: 04/05/2025
 import os
 
 import click
-from tabulate import tabulate
-
 from ndsware.parsers.nds import Nds
+from tabulate import tabulate
 
 CODE_FOLDER = "code"
 FILES_FOLDER = "files"
@@ -23,6 +22,53 @@ def cli() -> None:
     """
     Extracts data from key sections of the NDS ROM such as game code and files.
     """
+
+
+@cli.command()
+@click.argument("nds_file", type=str)
+def explore(nds_file: str) -> None:
+    nds = Nds.from_file(nds_file)
+    name_path: list[str] = []
+    directory_path: list[Nds.Directory] = [nds.file_name_table.directories[0]]
+
+    while True:
+        path_string = "/" + "/".join(name_path) + " > "
+        parts = input(path_string).split()
+        command = parts[0] if parts else ""
+        arguments = parts[1:] if len(parts) > 1 else []
+
+        match command:
+            case "ls":
+                for file in directory_path[-1].files[:-1]:
+                    symbol = "D" if file.is_directory else "_"
+                    print(symbol, "\t", file.name)
+            case "cd":
+                if len(arguments) > 0:
+                    change_directory(nds, name_path, directory_path, arguments[0])
+                else:
+                    print("ERROR: Must specify a directory to change to.")
+            case "exit":
+                break
+
+
+def change_directory(nds: Nds, name_path: list, directory_path: list, next_directory: str) -> None:
+    if next_directory == "..":
+        if len(name_path) > 0:
+            name_path.pop()
+            directory_path.pop()
+        else:
+            print("ERROR: Cannot traverse backwards from the root directory.")
+        return
+
+    for file in directory_path[-1].files[:-1]:
+        if file.name == next_directory and file.is_directory:
+            next_directory_index = file.directory_id & 0xFFF
+            next_directory = nds.file_name_table.directories[next_directory_index]
+            name_path.append(file.name)
+            directory_path.append(next_directory)
+            return
+
+    print(f"ERROR: '{next_directory}' is not a directory.")
 
 
 @cli.command(help="Display files/directory structure.")

--- a/python-package/src/ndsware/extract_nds.py
+++ b/python-package/src/ndsware/extract_nds.py
@@ -223,6 +223,8 @@ def process_explore_command(command: str, arguments: list[str], current_director
             current_directory = change_directory(arguments, current_directory)
         case "extract":
             explore_command_extract(arguments, current_directory)
+        case "help":
+            explore_command_help()
         case "exit":
             raise SystemExit("Goodbye!")
         case _:
@@ -255,6 +257,19 @@ def explore_command_extract(arguments: list[str], current_directory: FileNode) -
     target = current_directory.get(target_path)
 
     target.extract(output_path)
+
+
+def explore_command_help() -> None:
+    """List commands for the interactive shell."""
+
+    print(
+        """
+cd          Change directory.
+ls          List files and folders in the current directory.
+lsr         List files and folders in the current directory recursively.
+extract     Extract files/folders in the given directory.
+"""
+    )
 
 
 @cli.command(help="Display files/directory structure.")

--- a/python-package/src/ndsware/extract_nds.py
+++ b/python-package/src/ndsware/extract_nds.py
@@ -43,6 +43,13 @@ class FileNode:
 
         return self.file.data
 
+    def get_child(self, name: str) -> FileNode:
+        for child in self.children:
+            if child.name == name:
+                return child
+
+        raise ExploreException(f"`{name}` not found.")
+
     def get_folder(self, name: str) -> FileNode:
         for child in self.children:
             if child.is_directory() and child.name == name:
@@ -149,6 +156,8 @@ def process_explore_command(command: str, arguments: list[str], current_director
             print(current_directory.get_listings(recursive=True))
         case "cd":
             current_directory = change_directory(arguments, current_directory)
+        case "extract":
+            explore_command_extract(arguments, current_directory)
         case "exit":
             raise SystemExit("Goodbye!")
         case _:
@@ -168,6 +177,23 @@ def change_directory(arguments: list[str], current_directory: FileNode) -> FileN
         return current_directory.get_folder(arguments[0])
 
     raise ExploreException("Must specify a directory to change to.")
+
+
+def explore_command_extract(arguments: list[str], current_directory: FileNode) -> None:
+    if len(arguments) == 0:
+        raise ExploreException("Must specify an file or folder to extract.")
+
+    if len(arguments) == 1:
+        raise ExploreException("Must specify an output directory.")
+
+    target_name = arguments[0]
+    output_path = arguments[1]
+
+    target = current_directory
+    if target_name != ".":
+        target = target.get_child(target_name)
+
+    target.extract(output_path)
 
 
 @cli.command(help="Display files/directory structure.")

--- a/python-package/src/ndsware/extract_nds.py
+++ b/python-package/src/ndsware/extract_nds.py
@@ -17,6 +17,10 @@ FILES_FOLDER = "files"
 file_index = 0
 
 
+class ExploreException(Exception):
+    pass
+
+
 @click.group()
 def cli() -> None:
     """
@@ -36,7 +40,10 @@ def explore(nds_file: str) -> None:
         command = parts[0] if parts else ""
         arguments = parts[1:] if len(parts) > 1 else []
 
-        process_explore_command(nds, path, command, arguments)
+        try:
+            process_explore_command(nds, path, command, arguments)
+        except ExploreException as e:
+            print(f"ERROR: {e}")
 
 
 def process_explore_command(nds: Nds, path: dict[str, Nds.Directory], command: str, arguments: list[str]) -> None:
@@ -50,18 +57,20 @@ def process_explore_command(nds: Nds, path: dict[str, Nds.Directory], command: s
             if len(arguments) > 0:
                 change_directory(nds, path, arguments[0])
             else:
-                print("ERROR: Must specify a directory to change to.")
+                raise ExploreException("Must specify a directory to change to.")
         case "exit":
             raise SystemExit("Goodbye!")
+        case _:
+            raise ExploreException("Invalid command.")
 
 
 def change_directory(nds: Nds, path: dict[str, Nds.Directory], next_directory: str) -> None:
     if next_directory == "..":
         if len(path) > 1:
             path.popitem()
+            return
         else:
-            print("ERROR: Cannot traverse backwards from the root directory.")
-        return
+            raise ExploreException("Cannot traverse backwards from the root directory.")
 
     current_directory = next(reversed(path.values()))
     for file in current_directory.files[:-1]:
@@ -70,7 +79,7 @@ def change_directory(nds: Nds, path: dict[str, Nds.Directory], next_directory: s
             path[file.name] = nds.file_name_table.directories[next_directory_index]
             return
 
-    print(f"ERROR: '{next_directory}' is not a directory.")
+    raise ExploreException(f"'{next_directory}' is not a directory.")
 
 
 @cli.command(help="Display files/directory structure.")

--- a/python-package/src/ndsware/extract_nds.py
+++ b/python-package/src/ndsware/extract_nds.py
@@ -110,8 +110,8 @@ def explore(nds_file: str) -> None:
     current_directory: FileNode = FileNode.load_file_system(nds)
 
     while True:
-        path_string = current_directory.get_path() + " > "
-        parts = input(path_string).split()
+        prompt = f"{nds.header.game_title}:{current_directory.get_path()} > "
+        parts = input(prompt).split()
         command = parts[0] if parts else ""
         arguments = parts[1:] if len(parts) > 1 else []
 

--- a/python-package/src/ndsware/extract_nds.py
+++ b/python-package/src/ndsware/extract_nds.py
@@ -194,6 +194,8 @@ def cli() -> None:
 @cli.command()
 @click.argument("nds_file", type=str)
 def explore(nds_file: str) -> None:
+    """Open interactive shell to traverse the NDS file structure."""
+
     nds = Nds.from_file(nds_file)
     current_directory: FileNode = FileNode.load_file_system(nds)
 
@@ -210,6 +212,8 @@ def explore(nds_file: str) -> None:
 
 
 def process_explore_command(command: str, arguments: list[str], current_directory: FileNode) -> FileNode:
+    """Process commands entered into the interactive shell by the user."""
+
     match command:
         case "ls":
             print(current_directory.get_listings())
@@ -228,6 +232,8 @@ def process_explore_command(command: str, arguments: list[str], current_director
 
 
 def change_directory(arguments: list[str], current_directory: FileNode) -> FileNode:
+    """Handle the 'cd' command in the interactive shell."""
+
     if len(arguments) > 0:
         return current_directory.get_folder(arguments[0])
 
@@ -235,6 +241,8 @@ def change_directory(arguments: list[str], current_directory: FileNode) -> FileN
 
 
 def explore_command_extract(arguments: list[str], current_directory: FileNode) -> None:
+    """Handle the 'extract' command in the interactive shell."""
+
     if len(arguments) == 0:
         raise ExploreException("Must specify an file or folder to extract.")
 

--- a/python-package/src/ndsware/extract_nds.py
+++ b/python-package/src/ndsware/extract_nds.py
@@ -5,7 +5,10 @@ Author: CodeDragon82
 Data: 04/05/2025
 """
 
+from __future__ import annotations
+
 import os
+from typing import Optional
 
 import click
 from ndsware.parsers.nds import Nds
@@ -21,6 +24,78 @@ class ExploreException(Exception):
     pass
 
 
+class FileNode:
+    def __init__(self, name: str, parent: Optional[FileNode]):
+        self.name: str = name
+        self.parent: Optional[FileNode] = parent
+        self.children: list[FileNode] = []
+        self.file: Optional[Nds.File] = None
+
+    def add(self, child: FileNode) -> None:
+        self.children.append(child)
+
+    def set_file(self, file: Nds.File) -> None:
+        self.file = file
+
+    def get_file_data(self) -> bytes:
+        if self.file is None:
+            raise ExploreException("File doesn't have data.")
+
+        return self.file.data
+
+    def get_folder(self, name: str) -> FileNode:
+        for child in self.children:
+            if child.is_directory() and child.name == name:
+                return child
+
+        raise ExploreException(f"'{name}' is not a directory.")
+
+    def get_path(self) -> str:
+        if self.parent is None:
+            return "/"
+
+        return self.parent.get_path() + self.name + "/"
+
+    def get_listing(self) -> str:
+        if self.is_directory():
+            return f"D\t{self.name}"
+
+        info: Nds.FatEntry = self.file.info
+        size = info.end_offset - info.start_offset
+        return f"_\t{self.name}\t{size} B"
+
+    def is_directory(self) -> bool:
+        return self.file is None
+
+    def load(self, nds: Nds, directory: Nds.Directory) -> None:
+        global file_index
+
+        file: Nds.FileEntry
+        for file in reversed(directory.files[:-1]):
+            child_node = FileNode(file.name, self)
+            self.add(child_node)
+
+            if file.is_directory:
+                next_directory_index = file.directory_id & 0xFFF
+                next_directory = nds.file_name_table.directories[next_directory_index]
+
+                child_node.load(nds, next_directory)
+            else:
+                child_node.set_file(nds.files[file_index])
+                file_index -= 1
+
+    @staticmethod
+    def load_file_system(nds: Nds) -> FileNode:
+        global file_index
+        file_index = len(nds.files) - 1
+
+        root_directory = nds.file_name_table.directories[0]
+        root_node = FileNode("/", None)
+        root_node.load(nds, root_directory)
+
+        return root_node
+
+
 @click.group()
 def cli() -> None:
     """
@@ -32,54 +107,46 @@ def cli() -> None:
 @click.argument("nds_file", type=str)
 def explore(nds_file: str) -> None:
     nds = Nds.from_file(nds_file)
-    path: dict[str, Nds.Directory] = {"": nds.file_name_table.directories[0]}
+    current_directory: FileNode = FileNode.load_file_system(nds)
 
     while True:
-        path_string = "/".join(path.keys()) + " > "
+        path_string = current_directory.get_path() + " > "
         parts = input(path_string).split()
         command = parts[0] if parts else ""
         arguments = parts[1:] if len(parts) > 1 else []
 
         try:
-            process_explore_command(nds, path, command, arguments)
+            current_directory = process_explore_command(command, arguments, current_directory)
         except ExploreException as e:
             print(f"ERROR: {e}")
 
 
-def process_explore_command(nds: Nds, path: dict[str, Nds.Directory], command: str, arguments: list[str]) -> None:
+def process_explore_command(command: str, arguments: list[str], current_directory: FileNode) -> FileNode:
     match command:
         case "ls":
-            current_directory = next(reversed(path.values()))
-            for file in current_directory.files[:-1]:
-                symbol = "D" if file.is_directory else "_"
-                print(symbol, "\t", file.name)
+            for file in current_directory.children:
+                print(file.get_listing())
         case "cd":
-            if len(arguments) > 0:
-                change_directory(nds, path, arguments[0])
-            else:
-                raise ExploreException("Must specify a directory to change to.")
+            current_directory = change_directory(arguments, current_directory)
         case "exit":
             raise SystemExit("Goodbye!")
         case _:
             raise ExploreException("Invalid command.")
 
+    return current_directory
 
-def change_directory(nds: Nds, path: dict[str, Nds.Directory], next_directory: str) -> None:
-    if next_directory == "..":
-        if len(path) > 1:
-            path.popitem()
-            return
-        else:
-            raise ExploreException("Cannot traverse backwards from the root directory.")
 
-    current_directory = next(reversed(path.values()))
-    for file in current_directory.files[:-1]:
-        if file.name == next_directory and file.is_directory:
-            next_directory_index = file.directory_id & 0xFFF
-            path[file.name] = nds.file_name_table.directories[next_directory_index]
-            return
+def change_directory(arguments: list[str], current_directory: FileNode) -> FileNode:
+    if len(arguments) > 0:
+        if arguments[0] == "..":
+            if current_directory.parent is None:
+                raise ExploreException("Cannot traverse backwards from the root directory.")
 
-    raise ExploreException(f"'{next_directory}' is not a directory.")
+            return current_directory.parent
+
+        return current_directory.get_folder(arguments[0])
+
+    raise ExploreException("Must specify a directory to change to.")
 
 
 @cli.command(help="Display files/directory structure.")

--- a/python-package/src/ndsware/extract_nds.py
+++ b/python-package/src/ndsware/extract_nds.py
@@ -43,17 +43,42 @@ class FileNode:
 
         return self.file.data
 
-    def get_child(self, name: str) -> FileNode:
-        for child in self.children:
-            if child.name == name:
-                return child
+    def get(self, path: str) -> FileNode:
+        if path == "":
+            return self
 
-        raise ExploreException(f"`{name}` not found.")
+        if path[0] == "/":
+            return self.get_root().get(path[1:])
+
+        next_filename, *rest = path.split("/")
+        path_end = "/".join(rest)
+
+        if next_filename == ".":
+            return self.get(path_end)
+
+        if next_filename == "..":
+            if self.parent is None:
+                raise ExploreException("Cannot traverse backwards from the root directory.")
+
+            return self.parent.get(path_end)
+
+        for child in self.children:
+            if child.name == next_filename:
+                return child.get(path_end)
+
+        raise ExploreException(f"`{next_filename}` not found.")
+
+    def get_root(self) -> FileNode:
+        if self.parent is None:
+            return self
+
+        return self.parent
 
     def get_folder(self, name: str) -> FileNode:
-        for child in self.children:
-            if child.is_directory() and child.name == name:
-                return child
+        target = self.get(name)
+
+        if target.is_directory():
+            return target
 
         raise ExploreException(f"'{name}' is not a directory.")
 
@@ -168,12 +193,6 @@ def process_explore_command(command: str, arguments: list[str], current_director
 
 def change_directory(arguments: list[str], current_directory: FileNode) -> FileNode:
     if len(arguments) > 0:
-        if arguments[0] == "..":
-            if current_directory.parent is None:
-                raise ExploreException("Cannot traverse backwards from the root directory.")
-
-            return current_directory.parent
-
         return current_directory.get_folder(arguments[0])
 
     raise ExploreException("Must specify a directory to change to.")
@@ -186,12 +205,10 @@ def explore_command_extract(arguments: list[str], current_directory: FileNode) -
     if len(arguments) == 1:
         raise ExploreException("Must specify an output directory.")
 
-    target_name = arguments[0]
+    target_path = arguments[0]
     output_path = arguments[1]
 
-    target = current_directory
-    if target_name != ".":
-        target = target.get_child(target_name)
+    target = current_directory.get(target_path)
 
     target.extract(output_path)
 

--- a/python-package/src/ndsware/extract_nds.py
+++ b/python-package/src/ndsware/extract_nds.py
@@ -23,6 +23,8 @@ class ExploreException(Exception):
 
 
 class FileNode:
+    """Stores information about a file or folder loaded from the NDS file system."""
+
     file_index = 0
 
     def __init__(self, name: str, parent: Optional[FileNode]):
@@ -32,18 +34,26 @@ class FileNode:
         self.file: Optional[Nds.File] = None
 
     def add(self, child: FileNode) -> None:
+        """Add a new `FileNode` as a child of the current folder."""
+
         self.children.append(child)
 
     def set_file(self, file: Nds.File) -> None:
+        """Set the `File` data object for the `FileNode`."""
+
         self.file = file
 
     def get_file_data(self) -> bytes:
+        """Returns the file's byte data."""
+
         if self.file is None:
             raise ExploreException("File doesn't have data.")
 
         return self.file.data
 
     def get(self, path: str) -> FileNode:
+        """Get another `FileNode` in the file system given the path."""
+
         if path == "":
             return self
 
@@ -69,12 +79,16 @@ class FileNode:
         raise ExploreException(f"`{next_filename}` not found.")
 
     def get_root(self) -> FileNode:
+        """Get the root `FileNode` of the file system."""
+
         if self.parent is None:
             return self
 
         return self.parent
 
     def get_folder(self, name: str) -> FileNode:
+        """Get the `FileNode` of the given path and check that it's a folder."""
+
         target = self.get(name)
 
         if target.is_directory():
@@ -83,12 +97,21 @@ class FileNode:
         raise ExploreException(f"'{name}' is not a directory.")
 
     def get_path(self) -> str:
+        """Generate a string of the current file/folder's path in the file system."""
+
         if self.parent is None:
             return "/"
 
         return self.parent.get_path() + self.name + "/"
 
     def get_listing(self) -> str:
+        """
+        Returns a formatted string with the file’s details:
+        - Whether it is a directory
+        - Filename
+        - File size
+        """
+
         if self.is_directory():
             return f"D\t{self.name}"
 
@@ -97,6 +120,11 @@ class FileNode:
         return f"_\t{self.name}\t{size} B"
 
     def get_listings(self, recursive: bool = False, tab: int = 0) -> str:
+        """
+        Returns a formatted string of file and folder details from the given
+        directory. Listings can also be fetched recursively.
+        """
+
         listings = ""
 
         if self.is_directory():
@@ -108,6 +136,8 @@ class FileNode:
         return listings
 
     def extract(self, output_path: str) -> None:
+        """Extract file data or directory recursively to `output_path`."""
+
         output_path = os.path.join(output_path, self.name)
         print(output_path)
 
@@ -120,9 +150,13 @@ class FileNode:
             open(output_path, "wb").write(self.get_file_data())
 
     def is_directory(self) -> bool:
+        """Returns true if the `FileNode` represents a folder."""
+
         return self.file is None
 
     def load(self, nds: Nds, directory: Nds.Directory) -> None:
+        """Recursively generate the `FileNode`s for the given `directory`."""
+
         file: Nds.FileEntry
         for file in reversed(directory.files[:-1]):
             child_node = FileNode(file.name, self)
@@ -139,6 +173,8 @@ class FileNode:
 
     @staticmethod
     def load_file_system(nds: Nds) -> FileNode:
+        """Load the file system into a tree of `FileNode`s."""
+
         FileNode.file_index = len(nds.files) - 1
 
         root_directory = nds.file_name_table.directories[0]


### PR DESCRIPTION
This PR adds the `explore` command to the `extract_nds.py` CLI tool. This opens an interactive shell, allowing users to traverse the NDS file system without extracting it. The user can enter the following commands into the interactive shell:
- `cd` - Change directory.
- `ls` - List files and folders in the current directory.
- `lsr` - List files and folders in the current directory recursively.
- `extract` - Extract files/folders in the given directory.

Additionally, the `extract_nds.py` script has been refactored to improve the way it loads and handles the NDS file system. The file system is now stored as a tree of `FileNode` objects, which is loaded from the FAT and FNT (parsed by the Kaitai parser) by calling the `FileNode.load_file_system` function. Each `FileNode` references its parent and child nodes, and stores the following information:
- Whether it's a file or folder.
- Filename name
- File start and end offset (used to calculate size).
- File byte data.